### PR TITLE
Change UIKeyboardFrameBeginUserInfoKey to UIKeyboardFrameEndUserInfoKey.

### DIFF
--- a/Pod/Keyboardy.swift
+++ b/Pod/Keyboardy.swift
@@ -112,7 +112,7 @@ public extension UIViewController {
     /// Handler for `UIKeyboardWillShowNotification`
     fileprivate dynamic func keyboardWillShow(_ n: Notification) {
         if let userInfo = n.userInfo,
-            let rect = (userInfo[UIKeyboardFrameBeginUserInfoKey] as? NSValue)?.cgRectValue,
+            let rect = (userInfo[UIKeyboardFrameEndUserInfoKey] as? NSValue)?.cgRectValue,
             let duration = (userInfo[UIKeyboardAnimationDurationUserInfoKey] as? NSNumber)?.doubleValue,
             let curve = (userInfo[UIKeyboardAnimationCurveUserInfoKey] as? NSNumber)?.intValue {
             


### PR DESCRIPTION
`UIKeyboardFrameBeginUserInfoKey` does not work well with keyboards on iOS 11 beta.